### PR TITLE
Feature/Add nNecc market cap to info box

### DIFF
--- a/src/components/Bond/BondBox.jsx
+++ b/src/components/Bond/BondBox.jsx
@@ -377,6 +377,8 @@ export const BondBox = (props) => {
     ? bigNumberify(ndolnNECCPairMarketPrice)?.mul(expandDecimals(1, 18))
     : bigNumberify(0);
 
+  const nNeccMarketCap = nNeccCirculatingSupply?.mul(nNeccMarketPrice);
+
   const nNeccBondPrice =
     bondPrice && stakingCurrentIndex
       ? bigNumberify(bondPrice)
@@ -1558,6 +1560,7 @@ export const BondBox = (props) => {
               <ExchangeInfoRow label="nNecc Market Price">
                 {nNeccMarketPrice &&
                   formatAmount(nNeccMarketPrice, 18, 2, true)}{" "}
+                  USD
               </ExchangeInfoRow>
 
               <div className="Exchange-info-row">
@@ -1568,6 +1571,13 @@ export const BondBox = (props) => {
                   {"nNecc"}
                 </div>
               </div>
+
+
+              <ExchangeInfoRow label="nNecc Market Cap">
+                {nNeccMarketCap &&
+                  formatAmount(nNeccMarketCap, 36, 0, true)}{" "}
+                  USD
+              </ExchangeInfoRow>
 
               <hr className="my-2" />
 


### PR DESCRIPTION
<img width="540" alt="Screenshot 2021-12-30 at 20 59 02" src="https://user-images.githubusercontent.com/13225248/147787594-d8842be7-8f48-4f27-9324-096ba21706de.png">
